### PR TITLE
@neutronest Dev: PrettyPrint

### DIFF
--- a/src/main/scala/com/framex/core/FrameX.scala
+++ b/src/main/scala/com/framex/core/FrameX.scala
@@ -71,14 +71,13 @@ class FrameX(var data: Vector[Vector[ElemX]], var columnMap: Map[String, Int] = 
       columnWidths(colIdx) = col.map(x => x.elem.toString.length).max
     })
 
-    var sb : StringBuilder = new StringBuilder()
-    var allLength = 0
+    val sb : StringBuilder = new StringBuilder()
     // print header
     for ( i <- 0 to this.data.length-1) {
       sb.append(" | ")
       sb.append(columnNames(i) + " " * (columnWidths(i)  - columnNames(i).length))
     }
-    allLength = sb.length
+    val allLength = sb.length
     sb.append("\n")
     sb.append("-" * allLength + "\n")
 

--- a/src/main/scala/com/framex/core/FrameX.scala
+++ b/src/main/scala/com/framex/core/FrameX.scala
@@ -65,10 +65,11 @@ class FrameX(var data: Vector[Vector[ElemX]], var columnMap: Map[String, Int] = 
 
   def prettyPrint() : Unit = {
 
-    var columnWidths: ListBuffer[Int] = columnNames.map(_.length + 2).to[ListBuffer]
+    val columnWidths: ListBuffer[Int] = new ListBuffer[Int]
     List.range(0, this.data.length).map(colIdx => {
       val col = this.data(colIdx)
-      columnWidths(colIdx) = col.map(x => x.elem.toString.length).max
+      val rowDataMaxLength = col.map(x => x.elem.toString.length).max
+      columnWidths.append(math.max(rowDataMaxLength, columnNames(colIdx).length))
     })
 
     val sb : StringBuilder = new StringBuilder()

--- a/src/test/scala/com/framex/TestFrameX.scala
+++ b/src/test/scala/com/framex/TestFrameX.scala
@@ -15,9 +15,10 @@ class TestFrameX extends FlatSpec with Matchers {
       List("A", "B", "C", "D", "E"),
       List("2015-01-10", "2017-08-22", "2016-03-03", "2011-02-02", "2017-02-12"))
     val df = FrameX(ll)
-    df.data.foreach(f => f.foreach(
-      f2 => println(f2.elem)
-    ))
+
+    //    df.data.foreach(f => f.foreach(
+    //      f2 => println(f2.elem)
+    //    ))
 
     val ll2 = List(List(3), List("C"), List("2016-03-03"))
     val ll24 = List(List(3, 4, 5), List("C", "D", "E"), List("2016-03-03", "2011-02-02", "2017-02-12"))
@@ -154,7 +155,7 @@ class TestFrameX extends FlatSpec with Matchers {
     val columnNames = List("id", "word", "date")
     val df = FrameX(ll, columnNames)
     import df.::
-    df.loc(::, "date").data.foreach(f => f.foreach(f2 => println(f2.elem)))
+    //df.loc(::, "date").data.foreach(f => f.foreach(f2 => println(f2.elem)))
     df.loc(::, "date").equals(FrameX(List(List("2015-01-10", "2017-08-22", "2016-03-03", "2011-02-02", "2017-02-12")))) shouldEqual (true)
   }
 
@@ -169,6 +170,19 @@ class TestFrameX extends FlatSpec with Matchers {
     x.data shouldEqual Vector(
       Vector(ElemX("2017-08-22"), ElemX("2016-03-03"), ElemX("2011-02-02"))
     )
+  }
+
+  it should "prettyPrint" in {
+    val ll = List(List(1, 2, 3, 4, 5),
+      List("A", "B", "C", "D", "E"),
+      List("2015-01-10", "2017-08-22", "2016-03-03", "2011-02-02", "2017-02-12"),
+      List("Tom", "Axiba Warning", "Dong Chao", "Zhang zhi hao", "zzz"),
+      List("Man", "Woman", "Woman", "Man", "Man"))
+    val columnNames = List("id", "word", "date", "name" , "gender")
+    val df = FrameX(ll, columnNames)
+    df.prettyPrint()
+
+    true shouldEqual(true)
   }
 
   //  "Performance test" should "cost small time" in {


### PR DESCRIPTION
Change Log:

1. add "columnNames" method to get columnName list with corresponding columnMap orderby index
2. pretty print by default 5 line data with format.
